### PR TITLE
Battery nsensor recovery

### DIFF
--- a/src/battery.erl
+++ b/src/battery.erl
@@ -9,11 +9,15 @@
 -module(battery).
 -author("ubuntu").
 
--export([start_battery/1]).
+-export([start_battery/1,start_battery/3]).
 
 start_battery(Name) ->
 	put(baterry_lvl,100),
 	batteryMode(100.0,sleep,Name).
+
+start_battery(Name,State,Battery_level) ->
+	put(baterry_lvl,Battery_level),
+	batteryMode(Battery_level/1,State,Name).
 
 batteryMode(Battery_lvl,_,Sensor_ID) when Battery_lvl =< 0 ->
 	%Battery: Battery level 0% Power Off

--- a/src/battery.erl
+++ b/src/battery.erl
@@ -19,12 +19,16 @@ batteryMode(Battery_lvl,_,Sensor_ID) when Battery_lvl =< 0 ->
 	%Battery: Battery level 0% Power Off
 	sensor:power_off(Sensor_ID);
 batteryMode(Battery_lvl,awake,Sensor_ID) ->
-	New_Battery_lvl = battery_activity(Battery_lvl,300,3),				%awake for 3 s before sendig data and going back to sleep
-	sensor:gotoSleep(Sensor_ID),
-	batteryMode(New_Battery_lvl,sleep,Sensor_ID);
+	New_Battery_lvl = battery_activity(Sensor_ID,Battery_lvl,300,3),				%awake for 3 s before sendig data and going back to sleep
+	Sending_stat = sensor:gotoSleep(Sensor_ID),
+	Penalty = case Sending_stat of
+							sent -> 0.5;
+							not_sent -> 0.0
+						end,
+	batteryMode(New_Battery_lvl - Penalty,sleep,Sensor_ID);
 
 batteryMode(Battery_lvl,sleep,Sensor_ID) ->
-	New_Battery_lvl = battery_activity(Battery_lvl,900,1),				%sleep for 3 s before randomizing P
+	New_Battery_lvl = battery_activity(Sensor_ID,Battery_lvl,900,1),				%sleep for 3 s before randomizing P
 	%Battery: call sensor with request 'randomize_P'
 	Next_state = sensor:randomize_P(Sensor_ID),
 	case Next_state of
@@ -33,11 +37,17 @@ batteryMode(Battery_lvl,sleep,Sensor_ID) ->
 	end.
 
 
-battery_activity(Battery_lvl,_,0) ->	Battery_lvl;
-battery_activity(Battery_lvl,Timeout,Battery_drop) ->
+battery_activity(_Sensor_ID,Battery_lvl,_Timeout,0) ->	Battery_lvl;
+battery_activity(Sensor_ID,Battery_lvl,Timeout,Battery_drop) ->
 	timer:sleep(Timeout),
-	put(baterry_lvl,trunc(math:ceil(Battery_lvl - 0.1))),
-	battery_activity(Battery_lvl - 0.1, Timeout, Battery_drop - 1).
+	New_level = trunc(math:ceil(Battery_lvl - 0.1)),
+	case (get(baterry_lvl) - New_level) >= 5 of
+		true ->
+			sensor:set_battery(Sensor_ID,New_level),
+			put(baterry_lvl,New_level);
+		false -> ok
+	end,
+	battery_activity(Sensor_ID,Battery_lvl - 0.1, Timeout, Battery_drop - 1).
 
 
 

--- a/src/sensor.erl
+++ b/src/sensor.erl
@@ -12,13 +12,13 @@
 -behaviour(gen_statem).
 
 %% API
--export([start/1]).
+-export([start/2]).
 
 %% gen_statem callbacks
--export([init/1, format_status/2, gotoSleep/1, randomize_P/1, power_off/1, update_neighbors/2, idle/3, sleep/3, awake/3, handle_event/4, terminate/3,
+-export([init/1, format_status/2, gotoSleep/1, set_battery/2, randomize_P/1, power_off/1, update_neighbors/2, idle/3, sleep/3, awake/3, handle_event/4, terminate/3,
   code_change/4, callback_mode/0]).
 
--record('Sensor', {}).
+-record('Sensor', {name,position,compared_P,neighbors,battery_level,data_list}).
 
 -define(SERVER, ?MODULE).
 
@@ -31,9 +31,8 @@
 %% @doc Creates a gen_statem process which calls Module:init/1 to
 %% initialize. To ensure a synchronized start-up procedure, this
 %% function does not return until Module:init/1 has returned.
-start(Sensor_Pos) ->
-	%{ok, Sensor_PID} =
-	gen_statem:start(?MODULE, Sensor_Pos, []).
+start(Server,Sensor_Pos) ->
+	gen_statem:start(?MODULE, {Server,Sensor_Pos}, []).
 	%ets:insert(db,{Sensor_Pos, Sensor_PID}).
 
 %%%===================================================================
@@ -45,6 +44,9 @@ update_neighbors(Sensor_Name,NhbrList) ->
 gotoSleep(Sensor_Name) ->
 	gen_statem:call(Sensor_Name,gotoSleep).
 
+set_battery(Sensor_Name,New_level) ->
+	gen_statem:cast(Sensor_Name,{set_battery,New_level}).
+
 randomize_P(Sensor_Name) ->
 	gen_statem:call(Sensor_Name,randomize_P).
 
@@ -54,9 +56,10 @@ power_off(Sensor_Name) ->
 %% @doc Whenever a gen_statem is started using gen_statem:start/[3,4] or
 %% gen_statem:start_link/[3,4], this function is called by the new
 %% process to initialize.
-init(Sensor_Pos) ->
+init({Server,Sensor_Pos}) ->
+	put(server, Server),
 	P_comp = rand:uniform(4) + 94,
-  Data = #{name => self(), position => Sensor_Pos, compared_P => P_comp, neighbors => [], data_list => []},
+  Data = #{name => self(), position => Sensor_Pos, compared_P => P_comp, neighbors => [], battery_level => 100, data_list => []},
 	io:format("Sensor ~p initiated~n", [self()]), %ToDo:Temp comment
   {ok, idle, Data}.
 
@@ -90,36 +93,52 @@ idle({call,From}, {forward,_Data_List}, _Data) ->
 
 sleep({call,From}, randomize_P, #{position := Sensor_Pos, compared_P := P_comp, data_list := Data_List} = Data) ->
 	P = rand:uniform(100),  % uniformly randomized floating number between 1 - 100
-	{Next_State, New_Data_List} = case P > P_comp of
+	{Next_State, New_Data} = case P > P_comp of
 		true ->
 			Data_map = maps:new(),
 			graphic:update_sensor({Sensor_Pos,active}),
 			%%ToDo: monitor data and save in map,
-			{awake, Data_List ++ [Data_map]};
+			{awake, Data#{data_list := Data_List ++ [Data_map]}};
 		false ->
-			{sleep, Data_List}
+			{sleep, Data}
+	end,
+	case Next_State == awake of
+		true ->
+			server:updateETS(awake,New_Data);
+		false ->
+			ok
 	end,
 	%io:format("Sensor: next state = ~p, data list = ~p~n", [Next_State,New_Data_List]), %ToDo:Temp comment
-	{next_state,Next_State,Data#{data_list := New_Data_List},[{reply,From,Next_State}]};
+	{next_state,Next_State,New_Data,[{reply,From,Next_State}]};
 sleep({call,From}, {forward,_Data_List}, _Data) ->
-	{keep_state_and_data,[{reply,From,abort}]}.	%another sensor tried to send data to this sensor while in sleep mode - data not received
+	{keep_state_and_data,[{reply,From,abort}]};	%another sensor tried to send data to this sensor while in sleep mode - data not received
+sleep(cast, {set_battery,New_level}, Data) ->
+	server:updateETS(sleep,Data),
+	{keep_state,Data#{battery_level := New_level}}.
 
 
 awake({call,From}, gotoSleep, #{position := Sensor_Pos, neighbors := NhbrList, data_list := Data_List} = Data) ->
 	io:format("Sensor ~p: sending data to neighbors ~p ~n", [self(),NhbrList]), %ToDo:Temp comment
 	New_Data_List = send_data_to_neighbor(Sensor_Pos,NhbrList,Data_List),
-	%io:format("Sensor: new data list ~p ~n", [New_Data_List]), %ToDo:Temp comment
+	Reply = case New_Data_List of
+						[] -> sent;
+						_ -> not_sent
+					end,
+	server:updateETS(sleep,Data#{data_list := New_Data_List}),
 	graphic:update_sensor({Sensor_Pos,asleep}),
-	{next_state,sleep,Data#{data_list := New_Data_List},[{reply,From,ok}]};
+	{next_state,sleep,Data#{data_list := New_Data_List},[{reply,From,Reply}]};
 awake({call,From}, {forward,{From_SensorInPos,Rec_Data_List}}, #{data_list := Data_List} = Data) ->
 	io:format("Sensor ~p: got data from ~p ~n", [self(),From]), %ToDo:Temp comment
 	graphic:update_sensor({From_SensorInPos,sending}),
-	timer:sleep(1000),
+	timer:sleep(900),
 	New_Data_List = Data_List ++ Rec_Data_List,
 	graphic:update_sensor({From_SensorInPos,active}),
-	timer:sleep(600),
+	timer:sleep(300),
 	io:format("Sensor ~p: updated data list =~p ~n", [self(),New_Data_List]), %ToDo:Temp comment
-	{keep_state,Data#{data_list := New_Data_List},[{reply,From,sent}]}.
+	{keep_state,Data#{data_list := New_Data_List},[{reply,From,sent}]};
+awake(cast, {set_battery,New_level}, Data) ->
+	server:updateETS(awake,Data),
+	{keep_state,Data#{battery_level := New_level}}.
 
 
 

--- a/src/sensor.erl
+++ b/src/sensor.erl
@@ -104,7 +104,7 @@ sleep({call,From}, randomize_P, #{position := Sensor_Pos, compared_P := P_comp, 
 	end,
 	case Next_State == awake of
 		true ->
-			server:updateETS(awake,New_Data);
+			server:updateETS(awake,New_Data#'Sensor'.name,New_Data#'Sensor'.position,New_Data#'Sensor'.neighbors,New_Data#'Sensor'.battery_level,New_Data#'Sensor'.data_list);
 		false ->
 			ok
 	end,
@@ -113,7 +113,7 @@ sleep({call,From}, randomize_P, #{position := Sensor_Pos, compared_P := P_comp, 
 sleep({call,From}, {forward,_Data_List}, _Data) ->
 	{keep_state_and_data,[{reply,From,abort}]};	%another sensor tried to send data to this sensor while in sleep mode - data not received
 sleep(cast, {set_battery,New_level}, Data) ->
-	server:updateETS(sleep,Data),
+	server:updateETS(sleep,Data#'Sensor'.name,Data#'Sensor'.position,Data#'Sensor'.neighbors,New_level,Data#'Sensor'.data_list),
 	{keep_state,Data#{battery_level := New_level}}.
 
 
@@ -124,7 +124,7 @@ awake({call,From}, gotoSleep, #{position := Sensor_Pos, neighbors := NhbrList, d
 						[] -> sent;
 						_ -> not_sent
 					end,
-	server:updateETS(sleep,Data#{data_list := New_Data_List}),
+	server:updateETS(sleep,Data#'Sensor'.name,Data#'Sensor'.position,Data#'Sensor'.neighbors,Data#'Sensor'.battery_level,New_Data_List),
 	graphic:update_sensor({Sensor_Pos,asleep}),
 	{next_state,sleep,Data#{data_list := New_Data_List},[{reply,From,Reply}]};
 awake({call,From}, {forward,{From_SensorInPos,Rec_Data_List}}, #{data_list := Data_List} = Data) ->
@@ -137,7 +137,7 @@ awake({call,From}, {forward,{From_SensorInPos,Rec_Data_List}}, #{data_list := Da
 	io:format("Sensor ~p: updated data list =~p ~n", [self(),New_Data_List]), %ToDo:Temp comment
 	{keep_state,Data#{data_list := New_Data_List},[{reply,From,sent}]};
 awake(cast, {set_battery,New_level}, Data) ->
-	server:updateETS(awake,Data),
+	server:updateETS(awake,Data#'Sensor'.name,Data#'Sensor'.position,Data#'Sensor'.neighbors,New_level,Data#'Sensor'.data_list),
 	{keep_state,Data#{battery_level := New_level}}.
 
 

--- a/src/server.erl
+++ b/src/server.erl
@@ -12,7 +12,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0,updateETS/2]).
+-export([start_link/1,updateETS/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
@@ -29,8 +29,8 @@
 %% @doc Spawns the server and registers the local name (unique)
 -spec(start_link() ->
   {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
-start_link() ->
-  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+start_link(MainPC_ID) ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, MainPC_ID, []).
 
 updateETS(Sensor_Pos,Sensor_Data) ->    % Sensor_Data = {Name,Position,State,Neighbors,Battery_level,Data_list}
   gen_server:cast(?SERVER, {update_ets,Sensor_Pos,Sensor_Data}).
@@ -44,8 +44,9 @@ updateETS(Sensor_Pos,Sensor_Data) ->    % Sensor_Data = {Name,Position,State,Nei
 -spec(init(Args :: term()) ->
   {ok, State :: #server_state{}} | {ok, State :: #server_state{}, timeout() | hibernate} |
   {stop, Reason :: term()} | ignore).
-init([]) ->
-  ets:new(data_base,[set,public,named_table]),
+init(MainPC_ID) ->
+  register(main_PC,MainPC_ID),
+  ets:new(data_base,[set,public,named_table,{heir, MainPC_ID, heirData}]),
   Num_of_sensors = random:uniform(571) + 5, % number of sensors randomized between 6 - 576
   Pos_list = randomize_positions(Num_of_sensors,0,0), %ToDo: offsets are temp
   Sensor_PID_Pos_list = create_sensors(Pos_list),

--- a/src/server.erl
+++ b/src/server.erl
@@ -32,7 +32,7 @@
 start_link(MainPC_ID) ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, MainPC_ID, []).
 
-updateETS(Sensor_Pos,Sensor_Data) ->    % Sensor_Data = {Name,Position,State,Neighbors,Battery_level,Data_list}
+updateETS(Sensor_Pos,Sensor_Data) ->    % Sensor_Data = {State,Neighbors,P_comp,Battery_level,Data_list}
   gen_server:cast(?SERVER, {update_ets,Sensor_Pos,Sensor_Data}).
 
 %%%===================================================================


### PR DESCRIPTION
added recovery functions to battery.erl, sensor.erl and server.erl
now the sensor updates an hierarchical ets called data_base in the server on every change of state, battery_level or data
when the node that runs the servers process shuts down the ets switches its owner to main_PC
when main_PC finds proper node in witch the sensor will be recovered, it call's sensor:start with the data transferred with the ets